### PR TITLE
Add pagination error check to session tests

### DIFF
--- a/src/domain/sessions/use-cases/fetch-many-sessions-test.spec.ts
+++ b/src/domain/sessions/use-cases/fetch-many-sessions-test.spec.ts
@@ -3,6 +3,7 @@ import { InMemorySessionsRepository } from 'test/repositories/in-memory-sessions
 
 import { UniqueEntityId } from '@/core/entities/unique-entity-id'
 import { FetchManySessionsUseCase } from '@/domain/sessions/use-cases/fetch-many-sessions-use-case'
+import { InvalidPaginationParamsError } from '@/shared/errors/invalid-pagination-params-error'
 
 describe('Fetch Many Sessions Test', () => {
   let sessionsRepository: InMemorySessionsRepository
@@ -89,5 +90,9 @@ describe('Fetch Many Sessions Test', () => {
     })
 
     expect(result.isLeft()).toBe(true)
+
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(InvalidPaginationParamsError)
+    }
   })
 })


### PR DESCRIPTION
## Summary
- import `InvalidPaginationParamsError` in session fetch test
- assert invalid pagination returns `InvalidPaginationParamsError`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cd61e5da88323823d9b2f3a71590e